### PR TITLE
Downgrade pynvml for compatibility

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -1,3 +1,3 @@
 python3 -m pip install --upgrade pip
-python3 -m pip install taichi==1.6.0 scipy trimesh imageio matplotlib psutil pynvml shapely -i https://pypi.douban.com/simple
+python3 -m pip install taichi==1.6.0 scipy trimesh imageio matplotlib psutil pynvml==11.4.1 shapely -i https://pypi.douban.com/simple
 sudo apt-get install libeigen3-dev


### PR DESCRIPTION
Force pynvml to use prior version 11.4.1 as opposed to 11.5.3, which has known conflicts for newer versions of CUDA / NVIDIA Drivers which prevent GeoTaichi from working on many systems.

See:
https://github.com/Yihao-Shi/GeoTaichi/issues/12
and
https://github.com/wandb/wandb/issues/7168