### PR TITLE
Fix non-adjoint B-bar operator and volume-update linearization in 2D plane-strain (single-phase)

### DIFF
--- a/src/mpm/engines/EngineKernel.py
+++ b/src/mpm/engines/EngineKernel.py
@@ -1248,8 +1248,8 @@ def kernel_force_bbar_p2g_2D(total_nodes: int, particleNum: int, gravity: ti.typ
                 dshape_fnc = dshapefnc[ln]
                 temp_dshape = 0.5 * (dshape_fnc - dshape_fn)
                 external_force = shape_mapping(shapefn[ln], fex)
-                internal_force = vec2f([(dshape_fn[0] + temp_dshape[0]) * fInt[0] + temp_dshape[0] * fInt[1] + temp_dshape[0] * fInt[2] + dshape_fn[1] * fInt[3],
-                                        temp_dshape[1] * fInt[0] + (dshape_fn[1] + temp_dshape[1]) * fInt[1] + temp_dshape[1] * fInt[2] + dshape_fn[0] * fInt[3]])
+                internal_force = vec2f([(dshape_fn[0] + temp_dshape[0]) * fInt[0] + temp_dshape[0] * fInt[1] + dshape_fn[1] * fInt[3],
+                                        temp_dshape[1] * fInt[0] + (dshape_fn[1] + temp_dshape[1]) * fInt[1] + dshape_fn[0] * fInt[3]])
                 node[nodeID, bodyID]._update_nodal_force(external_force + internal_force)
 
 @ti.kernel
@@ -1744,14 +1744,13 @@ def kernel_update_velocity_gradient_2DAxisy(total_nodes: int, start_index: int, 
             particle[np].vol *= matProps.update_particle_volume(np, velocity_gradient, stateVars, dt)
 
 @ti.kernel
-def kernel_update_velocity_gradient_bbar_2D(total_nodes: int, start_index: int, end_index: int, dt: ti.template(), node: ti.template(), particle: ti.template(), materialID: ti.template(), matProps: ti.template(), stateVars: ti.template(), 
+def kernel_update_velocity_gradient_bbar_2D(total_nodes: int, start_index: int, end_index: int, dt: ti.template(), node: ti.template(), particle: ti.template(), materialID: ti.template(), matProps: ti.template(), stateVars: ti.template(),
                                      LnID: ti.template(), dshapefn: ti.template(), dshapefnc: ti.template(), node_size: ti.template()):
     for i in range(start_index, end_index):
         np = materialID[i]
         if int(particle[np].active) == 1:
             bodyID = int(particle[np].bodyID)
             velocity_gradient = ZEROMAT2x2
-            strain_rate_trace = ZEROVEC3f
             offset = np * total_nodes
             for ln in range(offset, offset + int(node_size[np])):
                 nodeID = LnID[ln]
@@ -1764,11 +1763,8 @@ def kernel_update_velocity_gradient_bbar_2D(total_nodes: int, start_index: int, 
                 velocity_gradient += outer_product2D(gv, dshape_fn)
                 velocity_gradient[0, 0] += average_bmatrix
                 velocity_gradient[1, 1] += average_bmatrix
-
-                strain_rate_trace[0] += dshape_fn[0] * gv[0]
-                strain_rate_trace[1] += dshape_fn[1] * gv[1]
             particle[np].velocity_gradient = truncation(velocity_gradient)
-            particle[np].vol *= matProps.update_particle_volume_bbar(np, strain_rate_trace, stateVars, dt)
+            particle[np].vol *= matProps.update_particle_volume_bbar_2D(np, velocity_gradient, stateVars, dt)
 
 @ti.kernel
 def kernel_update_velocity_gradient_bbar_2DAxisy(total_nodes: int, start_index: int, end_index: int, dt: ti.template(), node: ti.template(), particle: ti.template(), materialID: ti.template(), matProps: ti.template(), stateVars: ti.template(), 

--- a/src/physics_model/consititutive_model/infinitesimal_strain/InfinitesimalStrainModel.py
+++ b/src/physics_model/consititutive_model/infinitesimal_strain/InfinitesimalStrainModel.py
@@ -44,6 +44,10 @@ class InfinitesimalStrainModel(Solid):
         return 1. + dt[None] * (strain_rate[0] + strain_rate[1] + strain_rate[2])
 
     @ti.func
+    def update_particle_volume_bbar_2D(self, np, velocity_gradient, stateVars, dt):
+        return (ti.Matrix.identity(float, 2) + velocity_gradient * dt[None]).determinant()
+
+    @ti.func
     def ComputePKStress(self, np, previous_PKstress, velocity_gradient, stateVars, dt):  
         previous_cauchy_stress = self.PK2CauchyStress(np, previous_PKstress, stateVars)
         cauchy_stress = self.ComputeStress(np, previous_cauchy_stress, velocity_gradient, stateVars, dt)


### PR DESCRIPTION
## Summary

Two related but independent bugs in the 2D plane-strain B-bar path (single-phase, infinitesimal-strain models -- MohrCoulomb, DruckerPrager, LinearElastic, ModifiedCamClay, NorSand, StateDependentMohrCoulomb all inherit `InfinitesimalStrainModel` with no override, so both fixes apply to the whole family):

1. **`update_particle_volume_bbar` uses a first-order linearization (`1 + dt*tr(strain_rate)`) of a separately-accumulated, non-averaged strain rate**, instead of reusing the already-computed, properly B-bar-averaged `velocity_gradient` with the same determinant formula the non-bbar path already uses (`update_particle_volume_2D`). Applied multiplicatively every step (`particle.vol *= ...`), a single ill-conditioned step compounds. Added `update_particle_volume_bbar_2D` mirroring the existing `_2D` naming convention, and wired the 2D bbar kernel to use it with the correct matrix.

2. **`kernel_force_bbar_p2g_2D` couples a `sigma_zz` force contribution (`temp_dshape * fInt[2]`) into the nodal force with no conjugate strain term** -- `calculate_strain_rate2D` hardcodes `epsilon_zz = 0` in plane strain. Comparing against the 3D B-bar pair (`kernel_force_bbar_p2g` / `kernel_update_velocity_gradient_bbar`), which is self-consistent (all three diagonal terms present on both sides), the 2D kernel reads like a copy of the 3D one where the diagonal-averaging factor was correctly updated (1/3 -> 1/2) but the leftover `sigma_zz` coupling terms were never removed. With zero numerical damping (pure FLIP), this non-adjoint operator lets grid-scale modes grow unboundedly under load.

## Reproduction and validation

Rigid strip footing, plane-strain, GIMP + B-Bar, pushed into weightless associated Tresca soil -- verified against the exact closed-form bearing capacity oracle `N_c = 2+pi = 5.1416`. Before the fix, `n=80` (finer mesh) goes unstable: contact-force noise grows exponentially from the onset of plastic yielding (fitted slope of `log(force_std/force)` vs. step: `+0.0665`/frame, doubling every ~2100 steps), `N_c` swings between 2 and 33. Plain GIMP (no B-bar) at the same mesh is flat (`+0.0037`/frame, at the solver's own noise floor).

After fix #2 (fix #1 alone made no measurable difference to the growth rate -- `+0.0651` vs `+0.0665`, confirming it's a separate issue): growth slope is `-0.0021`/frame at `n=80` and `-0.0003`/frame at `n=40`, both flat and within the noise-floor range of B-bar-free control runs. `N_c` stable `5.2`-`5.4` throughout, matching the free-field controls.

Scope: this PR only touches the 2D plane-strain, single-phase path. The axisymmetric and twophase-2D B-bar kernels have a structurally similar pattern (visible by inspection) but are NOT touched here -- untested by this reproduction, left for a follow-up.